### PR TITLE
Add Spring Boot procurement app with deployment guide

### DIFF
--- a/procurement-app/.gitignore
+++ b/procurement-app/.gitignore
@@ -1,0 +1,2 @@
+target/
+uploads/

--- a/procurement-app/README.md
+++ b/procurement-app/README.md
@@ -1,0 +1,58 @@
+# Procurement App
+
+A Spring Boot application for collecting procurement information with user and admin roles.
+
+## Features
+
+- User registration and login with role-based access
+- Users can submit purchase records with PDF invoice uploads
+- Files are renamed as `item_price_date_user.pdf`
+- Admin dashboard to export all records as an Excel file
+- User home shows recent submissions and total value
+
+## Build and Run
+
+1. Install JDK 11+ and Maven.
+2. From the project root run:
+
+```bash
+mvn clean package
+```
+
+3. Start the application:
+
+```bash
+java -jar target/procurement-app-0.0.1-SNAPSHOT.jar
+```
+
+4. Visit `http://localhost:8080` in your browser.
+
+The application uses an in-memory H2 database and stores uploaded PDFs in the `uploads` directory.
+
+## 构建与运行（中文）
+
+1. 安装 JDK 11+ 和 Maven。
+2. 在项目根目录运行：
+
+```bash
+mvn clean package
+```
+
+3. 启动应用：
+
+```bash
+java -jar target/procurement-app-0.0.1-SNAPSHOT.jar
+```
+
+4. 在浏览器访问 `http://localhost:8080`。
+
+该应用使用内存中的 H2 数据库，并将上传的 PDF 文件存储在 `uploads` 目录。
+
+## Default Paths
+
+- Login: `/login`
+- User home: `/user/home`
+- Admin dashboard: `/admin/dashboard`
+- Export Excel: `/admin/export`
+
+A default administrator account (`admin` / `admin123`) is created on startup.

--- a/procurement-app/pom.xml
+++ b/procurement-app/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>procurement-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>procurement-app</name>
+    <description>Spring Boot Procurement Application</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.17</version>
+    </parent>
+
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/procurement-app/src/main/java/com/example/procurement/ProcurementApplication.java
+++ b/procurement-app/src/main/java/com/example/procurement/ProcurementApplication.java
@@ -1,0 +1,11 @@
+package com.example.procurement;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ProcurementApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ProcurementApplication.class, args);
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/config/DataInitializer.java
+++ b/procurement-app/src/main/java/com/example/procurement/config/DataInitializer.java
@@ -1,0 +1,31 @@
+package com.example.procurement.config;
+
+import com.example.procurement.model.Role;
+import com.example.procurement.model.User;
+import com.example.procurement.repository.RoleRepository;
+import com.example.procurement.repository.UserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class DataInitializer {
+
+    @Bean
+    public CommandLineRunner initUsers(UserRepository userRepository,
+                                       RoleRepository roleRepository,
+                                       PasswordEncoder passwordEncoder) {
+        return args -> {
+            if (userRepository.findByUsername("admin").isEmpty()) {
+                Role adminRole = roleRepository.findById("ROLE_ADMIN")
+                        .orElseGet(() -> roleRepository.save(new Role("ROLE_ADMIN")));
+                User admin = new User();
+                admin.setUsername("admin");
+                admin.setPassword(passwordEncoder.encode("admin123"));
+                admin.getRoles().add(adminRole);
+                userRepository.save(admin);
+            }
+        };
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/config/SecurityConfig.java
+++ b/procurement-app/src/main/java/com/example/procurement/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.example.procurement.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final UserDetailsService userDetailsService;
+
+    public SecurityConfig(UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeRequests()
+                .antMatchers("/admin/**").hasRole("ADMIN")
+                .antMatchers("/user/**").hasRole("USER")
+                .antMatchers("/", "/login", "/register", "/css/**").permitAll()
+                .anyRequest().authenticated()
+            .and()
+            .formLogin()
+                .loginPage("/login").defaultSuccessUrl("/user/home", true)
+            .and()
+            .logout()
+                .logoutSuccessUrl("/login?logout")
+            .and()
+            .userDetailsService(userDetailsService);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/controller/AdminController.java
+++ b/procurement-app/src/main/java/com/example/procurement/controller/AdminController.java
@@ -1,0 +1,28 @@
+package com.example.procurement.controller;
+
+import com.example.procurement.service.ExportService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Controller
+public class AdminController {
+
+    private final ExportService exportService;
+
+    public AdminController(ExportService exportService) {
+        this.exportService = exportService;
+    }
+
+    @GetMapping("/admin/export")
+    public void export(HttpServletResponse response) throws IOException {
+        exportService.exportAll(response);
+    }
+
+    @GetMapping("/admin/dashboard")
+    public String dashboard() {
+        return "admin/dashboard";
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/controller/AuthController.java
+++ b/procurement-app/src/main/java/com/example/procurement/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.example.procurement.controller;
+
+import com.example.procurement.model.User;
+import com.example.procurement.service.UserService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+public class AuthController {
+
+    private final UserService userService;
+
+    public AuthController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/login")
+    public String login() {
+        return "login";
+    }
+
+    @GetMapping("/register")
+    public String registerForm(Model model) {
+        model.addAttribute("user", new User());
+        return "register";
+    }
+
+    @PostMapping("/register")
+    public String register(User user) {
+        userService.registerUser(user);
+        return "redirect:/login";
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/controller/HomeController.java
+++ b/procurement-app/src/main/java/com/example/procurement/controller/HomeController.java
@@ -1,0 +1,12 @@
+package com.example.procurement.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+    @GetMapping("/")
+    public String index() {
+        return "redirect:/login";
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/controller/PurchaseController.java
+++ b/procurement-app/src/main/java/com/example/procurement/controller/PurchaseController.java
@@ -1,0 +1,44 @@
+package com.example.procurement.controller;
+
+import com.example.procurement.service.PurchaseService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.security.Principal;
+import java.time.LocalDate;
+
+@Controller
+public class PurchaseController {
+
+    private final PurchaseService purchaseService;
+
+    public PurchaseController(PurchaseService purchaseService) {
+        this.purchaseService = purchaseService;
+    }
+
+    @PostMapping("/user/purchase")
+    public String submitPurchase(@RequestParam String itemName,
+                                 @RequestParam BigDecimal price,
+                                 @RequestParam(required = false) String link,
+                                 @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate purchaseDate,
+                                 @RequestParam("file") MultipartFile file,
+                                 Principal principal) throws IOException {
+        purchaseService.savePurchase(itemName, price, link, purchaseDate, file, principal.getName());
+        return "redirect:/user/home";
+    }
+
+    @GetMapping("/user/home")
+    public String userHome(Model model, Principal principal) {
+        String username = principal.getName();
+        model.addAttribute("records", purchaseService.findByUser(username));
+        model.addAttribute("totalValue", purchaseService.sumByUser(username));
+        return "user/home";
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/model/PurchaseRecord.java
+++ b/procurement-app/src/main/java/com/example/procurement/model/PurchaseRecord.java
@@ -1,0 +1,34 @@
+package com.example.procurement.model;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+public class PurchaseRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String itemName;
+    private BigDecimal price;
+    private String link;
+    private LocalDate purchaseDate;
+    private String purchaser;
+    private String invoiceFileName;
+
+    // getters and setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+    public BigDecimal getPrice() { return price; }
+    public void setPrice(BigDecimal price) { this.price = price; }
+    public String getLink() { return link; }
+    public void setLink(String link) { this.link = link; }
+    public LocalDate getPurchaseDate() { return purchaseDate; }
+    public void setPurchaseDate(LocalDate purchaseDate) { this.purchaseDate = purchaseDate; }
+    public String getPurchaser() { return purchaser; }
+    public void setPurchaser(String purchaser) { this.purchaser = purchaser; }
+    public String getInvoiceFileName() { return invoiceFileName; }
+    public void setInvoiceFileName(String invoiceFileName) { this.invoiceFileName = invoiceFileName; }
+}

--- a/procurement-app/src/main/java/com/example/procurement/model/Role.java
+++ b/procurement-app/src/main/java/com/example/procurement/model/Role.java
@@ -1,0 +1,15 @@
+package com.example.procurement.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class Role {
+    @Id
+    private String name;
+
+    public Role() {}
+    public Role(String name) { this.name = name; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/procurement-app/src/main/java/com/example/procurement/model/User.java
+++ b/procurement-app/src/main/java/com/example/procurement/model/User.java
@@ -1,0 +1,32 @@
+package com.example.procurement.model;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String username;
+    private String password;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+        name = "user_roles",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_name")
+    )
+    private Set<Role> roles = new HashSet<>();
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public Set<Role> getRoles() { return roles; }
+    public void setRoles(Set<Role> roles) { this.roles = roles; }
+}

--- a/procurement-app/src/main/java/com/example/procurement/repository/PurchaseRecordRepository.java
+++ b/procurement-app/src/main/java/com/example/procurement/repository/PurchaseRecordRepository.java
@@ -1,0 +1,6 @@
+package com.example.procurement.repository;
+
+import com.example.procurement.model.PurchaseRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PurchaseRecordRepository extends JpaRepository<PurchaseRecord, Long> {}

--- a/procurement-app/src/main/java/com/example/procurement/repository/RoleRepository.java
+++ b/procurement-app/src/main/java/com/example/procurement/repository/RoleRepository.java
@@ -1,0 +1,6 @@
+package com.example.procurement.repository;
+
+import com.example.procurement.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, String> {}

--- a/procurement-app/src/main/java/com/example/procurement/repository/UserRepository.java
+++ b/procurement-app/src/main/java/com/example/procurement/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.procurement.repository;
+
+import com.example.procurement.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/procurement-app/src/main/java/com/example/procurement/service/ExportService.java
+++ b/procurement-app/src/main/java/com/example/procurement/service/ExportService.java
@@ -1,0 +1,49 @@
+package com.example.procurement.service;
+
+import com.example.procurement.model.PurchaseRecord;
+import com.example.procurement.repository.PurchaseRecordRepository;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+@Service
+public class ExportService {
+
+    private final PurchaseRecordRepository repository;
+
+    public ExportService(PurchaseRecordRepository repository) {
+        this.repository = repository;
+    }
+
+    public void exportAll(HttpServletResponse response) throws IOException {
+        List<PurchaseRecord> records = repository.findAll();
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("Purchases");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("Item");
+        header.createCell(1).setCellValue("Price");
+        header.createCell(2).setCellValue("Date");
+        header.createCell(3).setCellValue("Purchaser");
+
+        int rowIdx = 1;
+        for (PurchaseRecord r : records) {
+            Row row = sheet.createRow(rowIdx++);
+            row.createCell(0).setCellValue(r.getItemName());
+            row.createCell(1).setCellValue(r.getPrice().doubleValue());
+            row.createCell(2).setCellValue(r.getPurchaseDate().toString());
+            row.createCell(3).setCellValue(r.getPurchaser());
+        }
+
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename=purchases.xlsx");
+        workbook.write(response.getOutputStream());
+        workbook.close();
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/service/PurchaseService.java
+++ b/procurement-app/src/main/java/com/example/procurement/service/PurchaseService.java
@@ -1,0 +1,59 @@
+package com.example.procurement.service;
+
+import com.example.procurement.model.PurchaseRecord;
+import com.example.procurement.repository.PurchaseRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class PurchaseService {
+
+    private final PurchaseRecordRepository repository;
+    private final Path uploadDir = Paths.get("uploads");
+
+    public PurchaseService(PurchaseRecordRepository repository) throws IOException {
+        this.repository = repository;
+        if (!Files.exists(uploadDir)) {
+            Files.createDirectories(uploadDir);
+        }
+    }
+
+    public void savePurchase(String itemName, BigDecimal price, String link,
+                             LocalDate date, MultipartFile file, String username) throws IOException {
+        String newFileName = itemName + "_" + price + "_" + date + "_" + username + ".pdf";
+        Files.copy(file.getInputStream(), uploadDir.resolve(newFileName), StandardCopyOption.REPLACE_EXISTING);
+
+        PurchaseRecord record = new PurchaseRecord();
+        record.setItemName(itemName);
+        record.setPrice(price);
+        record.setLink(link);
+        record.setPurchaseDate(date);
+        record.setPurchaser(username);
+        record.setInvoiceFileName(newFileName);
+        repository.save(record);
+    }
+
+    public long sumByUser(String username) {
+        return repository.findAll().stream()
+                .filter(r -> r.getPurchaser().equals(username))
+                .mapToLong(r -> r.getPrice().longValue()).sum();
+    }
+
+    public List<PurchaseRecord> findByUser(String username) {
+        return repository.findAll().stream()
+                .filter(r -> r.getPurchaser().equals(username))
+                .sorted(Comparator.comparing(PurchaseRecord::getPurchaseDate).reversed())
+                .collect(Collectors.toList());
+    }
+}

--- a/procurement-app/src/main/java/com/example/procurement/service/UserService.java
+++ b/procurement-app/src/main/java/com/example/procurement/service/UserService.java
@@ -1,0 +1,45 @@
+package com.example.procurement.service;
+
+import com.example.procurement.model.Role;
+import com.example.procurement.model.User;
+import com.example.procurement.repository.RoleRepository;
+import com.example.procurement.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, RoleRepository roleRepository,
+                       PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public void registerUser(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        Role userRole = roleRepository.findById("ROLE_USER")
+                .orElseGet(() -> roleRepository.save(new Role("ROLE_USER")));
+        user.getRoles().add(userRole);
+        userRepository.save(user);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        UserBuilder builder = org.springframework.security.core.userdetails.User.withUsername(username)
+                .password(user.getPassword())
+                .roles(user.getRoles().stream().map(r -> r.getName().substring(5)).toArray(String[]::new));
+        return builder.build();
+    }
+}

--- a/procurement-app/src/main/resources/application.properties
+++ b/procurement-app/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:procurementdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/procurement-app/src/main/resources/static/css/style.css
+++ b/procurement-app/src/main/resources/static/css/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+form div { margin-bottom: 10px; }

--- a/procurement-app/src/main/resources/templates/admin/dashboard.html
+++ b/procurement-app/src/main/resources/templates/admin/dashboard.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+</head>
+<body>
+<h2>Admin Dashboard</h2>
+<a th:href="@{/admin/export}">Export All Records</a>
+</body>
+</html>

--- a/procurement-app/src/main/resources/templates/login.html
+++ b/procurement-app/src/main/resources/templates/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+</head>
+<body>
+<form th:action="@{/login}" method="post">
+    <div><label>Username: <input type="text" name="username"/></label></div>
+    <div><label>Password: <input type="password" name="password"/></label></div>
+    <div><button type="submit">Login</button></div>
+</form>
+<a th:href="@{/register}">Register</a>
+</body>
+</html>

--- a/procurement-app/src/main/resources/templates/register.html
+++ b/procurement-app/src/main/resources/templates/register.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+</head>
+<body>
+<form th:action="@{/register}" method="post" th:object="${user}">
+    <div><label>Username: <input type="text" th:field="*{username}"/></label></div>
+    <div><label>Password: <input type="password" th:field="*{password}"/></label></div>
+    <div><button type="submit">Register</button></div>
+</form>
+<a th:href="@{/login}">Back to login</a>
+</body>
+</html>

--- a/procurement-app/src/main/resources/templates/user/home.html
+++ b/procurement-app/src/main/resources/templates/user/home.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>User Home</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+</head>
+<body>
+<h2>Welcome, <span th:text="${#authentication.name}"></span></h2>
+<p>Total value submitted: <span th:text="${totalValue}">0</span></p>
+
+<form th:action="@{/user/purchase}" method="post" enctype="multipart/form-data">
+    <input type="text" name="itemName" placeholder="Item name" required />
+    <input type="number" name="price" placeholder="Price" step="0.01" required />
+    <input type="text" name="link" placeholder="Link" />
+    <input type="date" name="purchaseDate" required />
+    <input type="file" name="file" accept="application/pdf" required />
+    <button type="submit">Submit</button>
+</form>
+
+<h3>Recent records</h3>
+<table>
+    <tr><th>Item</th><th>Price</th><th>Date</th></tr>
+    <tr th:each="r : ${records}">
+        <td th:text="${r.itemName}"></td>
+        <td th:text="${r.price}"></td>
+        <td th:text="${r.purchaseDate}"></td>
+    </tr>
+</table>
+
+<a th:href="@{/logout}">Logout</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Spring Boot procurement information collection application
- include basic security, file upload, admin export, and default admin account
- document build instructions and default paths
- add Chinese deployment guide translation

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bae8f0d67c832cad6b30b4f4c68bb9